### PR TITLE
Add support for custom URLs to WASM binaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /**
  * @typedef {import('./lib/index.js').Grammar} Grammar
  * @typedef {import('./lib/index.js').Root} Root
+ * @typedef {import('./lib/index.js').Options} Options
+ * @typedef {import('./lib/index.js').GetOnigurumaUrl} GetOnigurumaUrl
  */
 
 export {grammars as all} from './lib/all.js'

--- a/lib/get-oniguruma.fetch.js
+++ b/lib/get-oniguruma.fetch.js
@@ -1,16 +1,19 @@
 /* eslint-env browser */
 
 /**
+ * @typedef {import('./index.js').Options} Options
+ */
+
+/**
  * Browser (and Node 18+) WASM loader.
  *
- * @typedef {import('./index.js').Options} Options
- * @param {Options} [options]
+ * @param {Options | undefined} [options]
  */
 export async function getOniguruma(options) {
-  let url = new URL('https://esm.sh/vscode-oniguruma@1/release/onig.wasm')
-  if (options && typeof options.getOnigurumaUrlFetch === 'function') {
-    url = await options.getOnigurumaUrlFetch()
-  }
+  const url =
+    options && options.getOnigurumaUrlFetch
+      ? await options.getOnigurumaUrlFetch()
+      : new URL('https://esm.sh/vscode-oniguruma@1/release/onig.wasm')
 
   // @ts-expect-error: TS doesn’t understand Fetch in Node yet.
   return fetch(url)

--- a/lib/get-oniguruma.fetch.js
+++ b/lib/get-oniguruma.fetch.js
@@ -1,7 +1,17 @@
 /* eslint-env browser */
 
-/* Browser (and Node 18+) WASM loader. */
-export async function getOniguruma() {
+/**
+ * Browser (and Node 18+) WASM loader.
+ *
+ * @typedef {import('./index.js').Options} Options
+ * @param {Options} [options]
+ */
+export async function getOniguruma(options) {
+  let url = new URL('https://esm.sh/vscode-oniguruma@1/release/onig.wasm')
+  if (options && typeof options.getOnigurumaUrlFetch === 'function') {
+    url = await options.getOnigurumaUrlFetch()
+  }
+
   // @ts-expect-error: TS doesn’t understand Fetch in Node yet.
-  return fetch('https://esm.sh/vscode-oniguruma@1/release/onig.wasm')
+  return fetch(url)
 }

--- a/lib/get-oniguruma.js
+++ b/lib/get-oniguruma.js
@@ -1,19 +1,20 @@
+/**
+ * @typedef {import('./index.js').Options} Options
+ */
+
 import fs from 'node:fs/promises'
 import {resolve} from 'import-meta-resolve'
 
 /**
  * Node w/o fetch.
  *
- * @typedef {import('./index.js').Options} Options
- * @param {Options} [options]
+ * @param {Options | undefined} [options]
  */
 export async function getOniguruma(options) {
-  const pkgUrl = await resolve('vscode-oniguruma', import.meta.url)
-  let url = new URL('onig.wasm', pkgUrl)
-
-  if (options && typeof options.getOnigurumaUrlFs === 'function') {
-    url = await options.getOnigurumaUrlFs()
-  }
+  const url =
+    options && options.getOnigurumaUrlFs
+      ? await options.getOnigurumaUrlFs()
+      : new URL('onig.wasm', await resolve('vscode-oniguruma', import.meta.url))
 
   return fs.readFile(url)
 }

--- a/lib/get-oniguruma.js
+++ b/lib/get-oniguruma.js
@@ -1,8 +1,19 @@
 import fs from 'node:fs/promises'
 import {resolve} from 'import-meta-resolve'
 
-/** Node w/o fetch. */
-export async function getOniguruma() {
+/**
+ * Node w/o fetch.
+ *
+ * @typedef {import('./index.js').Options} Options
+ * @param {Options} [options]
+ */
+export async function getOniguruma(options) {
   const pkgUrl = await resolve('vscode-oniguruma', import.meta.url)
-  return fs.readFile(new URL('onig.wasm', pkgUrl))
+  let url = new URL('onig.wasm', pkgUrl)
+
+  if (options && typeof options.getOnigurumaUrlFs === 'function') {
+    url = await options.getOnigurumaUrlFs()
+  }
+
+  return fs.readFile(url)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,22 @@
  * @property {Captures} captures
  *
  * @typedef {Record<number|string, Rule>} Captures
+ *
+ * @typedef Options
+ * Configuration (optional)
+ * @property {GetOnigurumaUrl} [getOnigurumaUrlFetch]
+ *   Get a URL to the oniguruma WASM, typically used in browsers.
+ * @property {GetOnigurumaUrl} [getOnigurumaUrlFs]
+ *   Get a URL to the oniguruma WASM, typically used in Node.js.
+ *
+ * @callback GetOnigurumaUrl
+ *   Get a Url to the oniguruma WASM.
+ *
+ *   > 👉 **Note**: this must currently result in a version 1 binary of
+ *   > `onig.wasm` from `vscode-oniguruma`.
+ * @returns {URL|Promise<URL>}
+ *   URL object to a WASM binary.
+ *
  */
 
 import vscodeTextmate from 'vscode-textmate'
@@ -66,15 +82,17 @@ import {theme} from './theme.js'
  *
  * @param {Array<Grammar>} grammars
  *   Grammars to support.
+ * @param {Options} [options]
+ *   Configuration (optional).
  */
-export async function createStarryNight(grammars) {
+export async function createStarryNight(grammars, options) {
   /** @type {Map<string, Grammar>} */
   const registered = new Map()
   /** @type {Map<string, string>} */
   const names = new Map()
   /** @type {Map<string, string>} */
   const extensions = new Map()
-  let currentRegistry = await createRegistry(grammars)
+  let currentRegistry = await createRegistry(grammars, options)
 
   return {flagToScope, scopes, register, highlight}
 
@@ -168,8 +186,9 @@ export async function createStarryNight(grammars) {
 
   /**
    * @param {Array<Grammar>} grammars
+   * @param {Options} [options]
    */
-  async function createRegistry(grammars) {
+  async function createRegistry(grammars, options) {
     for (const grammar of grammars) {
       const scope = grammar.scopeName
       for (const d of grammar.extensions) extensions.set(d, scope)
@@ -178,7 +197,7 @@ export async function createStarryNight(grammars) {
     }
 
     const registry = new vscodeTextmate.Registry({
-      onigLib: createOniguruma(),
+      onigLib: createOniguruma(options),
       // @ts-expect-error: `vscode-textmate` has much stricter types that needed
       // by textmate, or by what they actually support.
       // Given that we can’t fix the grammars provided by the world here, and
@@ -206,9 +225,11 @@ export async function createStarryNight(grammars) {
  *
  * Idea: as this seems to be a singleton, would it help if we call it once and
  * keep the promise?
+ *
+ * @param {Options} [options]
  */
-async function createOniguruma() {
-  const wasmBin = await getOniguruma()
+async function createOniguruma(options) {
+  const wasmBin = await getOniguruma(options)
   await vscodeOniguruma.loadWASM(wasmBin)
   return vscodeOniguruma
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,20 +52,19 @@
  * @typedef {Record<number|string, Rule>} Captures
  *
  * @typedef Options
- * Configuration (optional)
+ *   Configuration (optional).
  * @property {GetOnigurumaUrl} [getOnigurumaUrlFetch]
  *   Get a URL to the oniguruma WASM, typically used in browsers.
  * @property {GetOnigurumaUrl} [getOnigurumaUrlFs]
  *   Get a URL to the oniguruma WASM, typically used in Node.js.
  *
  * @callback GetOnigurumaUrl
- *   Get a Url to the oniguruma WASM.
+ *   Get a URL to the oniguruma WASM.
  *
- *   > 👉 **Note**: this must currently result in a version 1 binary of
+ *   > 👉 **Note**: this must currently result in a version 1 URL of
  *   > `onig.wasm` from `vscode-oniguruma`.
  * @returns {URL|Promise<URL>}
  *   URL object to a WASM binary.
- *
  */
 
 import vscodeTextmate from 'vscode-textmate'

--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,16 @@ Function to get a URL to the oniguruma WASM.
 
 URL object to a WASM binary (`URL` or `Promise<URL>`).
 
+
+###### Example 
+```js
+import {createStarryNight, common} from '@wooorm/starry-night'
+
+const starryNight = await createStarryNight(common, {
+  getOnigurumaUrlFetch: () => new URL(window.location.origin + "onig.wasm")
+})
+```
+
 ### `starryNight.flagToScope(flag)`
 
 Get the grammar scope (such as `source.gfm`) associated with a grammar name

--- a/readme.md
+++ b/readme.md
@@ -192,16 +192,22 @@ Yields:
 This package exports the identifiers `createStarryNight`, `common`, and `all`.
 There is no default export.
 
-### `createStarryNight(grammars)`
+### `createStarryNight(grammars[, options])`
 
 Create a `StarryNight` that can highlight things based on the given `grammars`.
 This is async to facilitate async loading and registering, which is currently
-only used for WASM.
+only used for WASM.  
+Use the optional `Options` object to pass functions that resolve to a `URL`
+pointing to a `vscode-oniguruma` WASM binary.
+
+*Note: The URL must result in a version 1 `onig.wasm` from `vscode-oniguruma`*
 
 ###### Parameters
 
 *   `grammars` (`Array<Grammar>`)
     — grammars to support
+*   `options` (`Options`)
+    — `getOnigurumaUrlFs` for node.js w/o fetch and `getOnigurumaUrlFetch` for browser and node v18+ environments.
 
 ###### Returns
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ source and JavaScript!
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
-    *   [`createStarryNight(grammars)`](#createstarrynightgrammars-options)
+    *   [`createStarryNight(grammars[, options])`](#createstarrynightgrammars-options)
     *   [`starryNight.highlight(value, scope)`](#starrynighthighlightvalue-scope)
     *   [`starryNight.flagToScope(flag)`](#starrynightflagtoscopeflag)
     *   [`starryNight.scopes()`](#starrynightscopes)
@@ -196,14 +196,14 @@ There is no default export.
 
 Create a `StarryNight` that can highlight things based on the given `grammars`.
 This is async to facilitate async loading and registering, which is currently
-only used for WASM.  
+only used for WASM.
 
 ###### Parameters
 
 *   `grammars` (`Array<Grammar>`)
     — grammars to support
 *   `options` (`Options`)
-    — `configuration
+    — configuration
 
 ###### Returns
 
@@ -270,21 +270,25 @@ optional).
 Function to get a URL to the oniguruma WASM.
 
 > 👉 **Note**: this must currently result in a version 1 URL of
-> `onig.wasm` from `vscode-oniguruma`.
+> `onig.wasm` from `vscode-oniguruma`.  
+> ☝️ **Disclaimer**: Using this functionality may break your implementation
+if the static WASM you point to differs
+from the one released by `vscode-oniguruma`
 
 ###### Returns
 
 URL object to a WASM binary (`URL` or `Promise<URL>`).
 
+###### Example
 
-###### Example 
 ```js
 import {createStarryNight, common} from '@wooorm/starry-night'
 
 const starryNight = await createStarryNight(common, {
-  getOnigurumaUrlFetch: () => new URL(window.location.origin + "onig.wasm")
-})
-```
+  getOnigurumaUrlFetch() {
+    return new URL("/onig.wasm", window.location.href);
+  }
+}) ```
 
 ### `starryNight.flagToScope(flag)`
 
@@ -1426,8 +1430,8 @@ Changes should go to upstream repos and [`languages.yml`][languages-yml] in
 ## Types
 
 This package is fully typed with [TypeScript][].
-It exports additional `Grammar`, `Root`, `Options` and `GetOnigurumaUrl` types that model their respective
-interfaces.
+It exports additional `Grammar`, `Root`, `Options`, and `GetOnigurumaUrl`
+types that model their respective interfaces.
 
 ## Compatibility
 

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@ optional).
 Function to get a URL to the oniguruma WASM.
 
 > 👉 **Note**: this must currently result in a version 1 URL of
-> `onig.wasm` from `vscode-oniguruma`.\
+> `onig.wasm` from `vscode-oniguruma`.
 
 > ⚠️ **Danger**: when you use this functionality, your project might break at
 > any time (when reinstalling dependencies), except when you make sure that

--- a/readme.md
+++ b/readme.md
@@ -270,10 +270,10 @@ optional).
 Function to get a URL to the oniguruma WASM.
 
 > 👉 **Note**: this must currently result in a version 1 URL of
-> `onig.wasm` from `vscode-oniguruma`.  
+> `onig.wasm` from `vscode-oniguruma`.\
 > ☝️ **Disclaimer**: Using this functionality may break your implementation
-if the static WASM you point to differs
-from the one released by `vscode-oniguruma`
+> if the static WASM you point to differs
+> from the one released by `vscode-oniguruma`
 
 ###### Returns
 
@@ -288,7 +288,8 @@ const starryNight = await createStarryNight(common, {
   getOnigurumaUrlFetch() {
     return new URL("/onig.wasm", window.location.href);
   }
-}) ```
+})
+```
 
 ### `starryNight.flagToScope(flag)`
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ source and JavaScript!
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
-    *   [`createStarryNight(grammars)`](#createstarrynightgrammars)
+    *   [`createStarryNight(grammars)`](#createstarrynightgrammars-options)
     *   [`starryNight.highlight(value, scope)`](#starrynighthighlightvalue-scope)
     *   [`starryNight.flagToScope(flag)`](#starrynightflagtoscopeflag)
     *   [`starryNight.scopes()`](#starrynightscopes)
@@ -197,17 +197,13 @@ There is no default export.
 Create a `StarryNight` that can highlight things based on the given `grammars`.
 This is async to facilitate async loading and registering, which is currently
 only used for WASM.  
-Use the optional `Options` object to pass functions that resolve to a `URL`
-pointing to a `vscode-oniguruma` WASM binary.
-
-*Note: The URL must result in a version 1 `onig.wasm` from `vscode-oniguruma`*
 
 ###### Parameters
 
 *   `grammars` (`Array<Grammar>`)
     — grammars to support
 *   `options` (`Options`)
-    — `getOnigurumaUrlFs` for node.js w/o fetch and `getOnigurumaUrlFetch` for browser and node v18+ environments.
+    — `configuration
 
 ###### Returns
 
@@ -254,6 +250,31 @@ Yields:
   ]
 }
 ```
+
+#### `Options`
+
+Configuration (optional).
+
+###### `options.getOnigurumaUrlFetch`
+
+Get a URL to the oniguruma WASM, typically used in browsers (`GetOnigurumaUrl`,
+optional).
+
+###### `options.getOnigurumaUrlFs`
+
+Get a URL to the oniguruma WASM, typically used in Node.js (`GetOnigurumaUrl`,
+optional).
+
+#### `GetOnigurumaUrl`
+
+Function to get a URL to the oniguruma WASM.
+
+> 👉 **Note**: this must currently result in a version 1 URL of
+> `onig.wasm` from `vscode-oniguruma`.
+
+###### Returns
+
+URL object to a WASM binary (`URL` or `Promise<URL>`).
 
 ### `starryNight.flagToScope(flag)`
 
@@ -1395,7 +1416,7 @@ Changes should go to upstream repos and [`languages.yml`][languages-yml] in
 ## Types
 
 This package is fully typed with [TypeScript][].
-It exports additional `Grammar` and `Root` types that model their respective
+It exports additional `Grammar`, `Root`, `Options` and `GetOnigurumaUrl` types that model their respective
 interfaces.
 
 ## Compatibility

--- a/readme.md
+++ b/readme.md
@@ -271,9 +271,14 @@ Function to get a URL to the oniguruma WASM.
 
 > 👉 **Note**: this must currently result in a version 1 URL of
 > `onig.wasm` from `vscode-oniguruma`.\
-> ☝️ **Disclaimer**: Using this functionality may break your implementation
-> if the static WASM you point to differs
-> from the one released by `vscode-oniguruma`
+
+> ⚠️ **Danger**: when you use this functionality, your project might break at
+> any time (when reinstalling dependencies), except when you make sure that
+> the WASM binary you load manually is what our internally used
+> `vscode-oniguruma` dependency expects.
+> To solve this, you could for example use an npm script called `dependencies`
+> (which runs everytime `node_modules` is changed) which copies
+> `vscode-oniguruma/release/onig.wasm` to the place you want to host it.
 
 ###### Returns
 

--- a/test.js
+++ b/test.js
@@ -35,6 +35,18 @@ test('.flagToScope(flag)', async () => {
   assert.equal(starryNight.flagToScope('whatever'), undefined)
 })
 
+test('.createStarryNight with options', () => {
+  assert.rejects(
+    async () => {
+      await createStarryNight(common, {
+        getOnigurumaUrlFs: () => new URL('file:///foo/baz/onig.wasm')
+      })
+    },
+    /no such file or directory, open '\/foo\/baz\/onig.wasm'/,
+    "should throw when file at given URL can't be found"
+  )
+})
+
 test('.scopes()', async () => {
   const starryNight = await createStarryNight(common)
   const list = starryNight.scopes()

--- a/test.js
+++ b/test.js
@@ -42,8 +42,8 @@ test('.createStarryNight with options', () => {
         getOnigurumaUrlFs: () => new URL('file:///foo/baz/onig.wasm')
       })
     },
-    /no such file or directory, open '\/foo\/baz\/onig.wasm'/,
-    "should throw when file at given URL can't be found"
+    /no such file or directory/,
+    'should support `getOnigurumaUrlFs`'
   )
 })
 


### PR DESCRIPTION
To allow users to provide a `URL` to a locally hosted oniguruma WASM binary, this commit allows users to provide a function that returns a URL object to a different WASM oniguruma binary, it should .

The options object can receive a `getOnigurumaUrlFetch` and a `getOnigurumaUrlFs` property for browser and node. 

Closes #8 