### PR TITLE
Update @types/hast, hast-util-to-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "notice"
   ],
   "dependencies": {
-    "@types/hast": "^2.0.0",
+    "@types/hast": "^3.0.0",
     "import-meta-resolve": "^2.0.0",
     "vscode-oniguruma": "^1.0.0",
     "vscode-textmate": "^9.0.0"
@@ -62,7 +62,7 @@
     "c8": "^8.0.0",
     "css": "^3.0.0",
     "generate-github-markdown-css": "^5.0.0",
-    "hast-util-to-html": "^8.0.0",
+    "hast-util-to-html": "^9.0.0",
     "json-stable-stringify": "^1.0.0",
     "mdast-zone": "^5.0.0",
     "prettier": "^2.0.0",


### PR DESCRIPTION
This updates `@types/hast` and `hast-util-to-html` dependencies, so this works with all other libraries (i.e. hast-util-to-jsx-runtime) that got recently updated.