### PR TITLE
add punctuation.definition.block to class map

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -47,6 +47,7 @@ const scopeToClassGithub = {
   'meta.output': 'pl-c1',
   'meta.property-name': 'pl-c1',
   'meta.separator': 'pl-ms',
+  'punctuation.definition.block': 'pl-kos',
   'punctuation.definition.changed': 'pl-mc',
   'punctuation.definition.comment': 'pl-c',
   'punctuation.definition.deleted': 'pl-md',


### PR DESCRIPTION
The class map has been tested using the [JavaScript VSCode grammar](https://github.com/microsoft/vscode/tree/1.80.0/extensions/javascript), not the built-in Starry Night.

Code:

```js
export { Root } from 'hast'
```

Before:

```html
<span class="pl-k">export</span> { <span class="pl-smi">Root</span> } <span class="pl-k">from</span> <span class="pl-s"><span class="pl-pds">'</span>hast<span class="pl-pds">'</span></span>
```

After:

```html
<span class="pl-k">export</span> <span class="pl-kos">{</span> <span class="pl-smi">Root</span> <span class="pl-kos">}</span> <span class="pl-k">from</span> <span class="pl-s"><span class="pl-pds">'</span>hast<span class="pl-pds">'</span></span>
```