### PR TITLE
add punctuation.terminator.statement to class map

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -53,6 +53,7 @@ const scopeToClassGithub = {
   'punctuation.definition.inserted': 'pl-mi1',
   'punctuation.definition.string': 'pl-pds',
   'punctuation.section.embedded': 'pl-pse',
+  'punctuation.terminator.statement': 'pl-kos',
 
   // Note: orignally this is listed as `source` on GH.
   // However, every `source*` scope matches that in `vscode-textmate`, making it


### PR DESCRIPTION
The class map has been tested using the [JavaScript VSCode grammar](https://github.com/microsoft/vscode/tree/1.80.0/extensions/javascript), not the built-in Starry Night.

Code:

```js
let a;
```

Before:

```html
<span class="pl-k">let</span> <span class="pl-smi">a</span>;
```

After:

```html
<span class="pl-k">let</span> <span class="pl-smi">a</span><span class="pl-kos">;</span>
```