### PR TITLE
add punctuation.definition.parameters to class map

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -51,6 +51,7 @@ const scopeToClassGithub = {
   'punctuation.definition.comment': 'pl-c',
   'punctuation.definition.deleted': 'pl-md',
   'punctuation.definition.inserted': 'pl-mi1',
+  'punctuation.definition.parameters': 'pl-kos',
   'punctuation.definition.string': 'pl-pds',
   'punctuation.section.embedded': 'pl-pse',
 


### PR DESCRIPTION
The class map has been tested using the [JavaScript VSCode grammar](https://github.com/microsoft/vscode/tree/1.80.0/extensions/javascript), not the built-in Starry Night.

Code:

```js
function fn() {}
```

Before:

```html
<span class="pl-k">function</span> <span class="pl-en">fn</span>() {}
```

After:

```html
<span class="pl-k">function</span> <span class="pl-en">fn</span><span class="pl-kos">()</span> {}
```
