### PR TITLE
add meta.brace.square to class map

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -39,6 +39,7 @@ const scopeToClassGithub = {
   'markup.raw': 'pl-c1',
   'markup.untracked': 'pl-mi2',
   'message.error': 'pl-bu',
+  'meta.brace.square': 'pl-kos',
   'meta.diff.header': 'pl-c1',
   'meta.diff.header.from-file': 'pl-md',
   'meta.diff.header.to-file': 'pl-mi1',


### PR DESCRIPTION
The class map has been tested using the [JavaScript VSCode grammar](https://github.com/microsoft/vscode/tree/1.80.0/extensions/javascript), not the built-in Starry Night.

Code:

```js
[]
```

Before:

```html
[]
```

After:

```html
<span class="pl-kos">[]</span>
```
