### PR TITLE
add punctuation.accessor.optional to class map

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -47,6 +47,7 @@ const scopeToClassGithub = {
   'meta.output': 'pl-c1',
   'meta.property-name': 'pl-c1',
   'meta.separator': 'pl-ms',
+  'punctuation.accessor.optional': 'pl-kos',
   'punctuation.definition.changed': 'pl-mc',
   'punctuation.definition.comment': 'pl-c',
   'punctuation.definition.deleted': 'pl-md',


### PR DESCRIPTION
The class map has been tested using the [JavaScript VSCode grammar](https://github.com/microsoft/vscode/tree/1.80.0/extensions/javascript), not the built-in Starry Night.

Code:

```js
a?.b
```

Before:

```html
<span class="pl-smi">a</span>?.<span class="pl-smi">b</span>
```

After:

```html
<span class="pl-smi">a</span><span class="pl-kos">?.</span><span class="pl-smi">b</span>
```

GitHub:

```html
<span class="pl-s1">a</span><span class="pl-kos">?.</span><span class="pl-c1">b</span>
```
