### PR TITLE
add punctuation.decorator to class map

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -47,6 +47,7 @@ const scopeToClassGithub = {
   'meta.output': 'pl-c1',
   'meta.property-name': 'pl-c1',
   'meta.separator': 'pl-ms',
+  'punctuation.decorator': 'pl-kos',
   'punctuation.definition.changed': 'pl-mc',
   'punctuation.definition.comment': 'pl-c',
   'punctuation.definition.deleted': 'pl-md',


### PR DESCRIPTION
The class map has been tested using the [JavaScript VSCode grammar](https://github.com/microsoft/vscode/tree/1.80.0/extensions/javascript), not the built-in Starry Night.

Code:

```js
@a
```

Before:

```html
@<span class="pl-smi">a</span>
```

After:

```html
<span class="pl-kos">@</span><span class="pl-smi">a</span>
```

GitHub:

```js
@<span class="pl-s1">a</span>
```